### PR TITLE
Support python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python: 
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 
 install:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please see https://zensend.io/public/docs for the most up-to-date documentation.
 
 ## Testing
 
-We commit to being compatible with Python 2.6+, Python 3.1+ and PyPy.  We need to test against all of these environments to ensure compatibility. For local testing, we use [tox](http://tox.readthedocs.org/) to handle testing across environments.
+We commit to being compatible with Python 2.6+, Python 3.3+ and PyPy.  We need to test against all of these environments to ensure compatibility. For local testing, we use [tox](http://tox.readthedocs.org/) to handle testing across environments.
 
 ## Manual Testing
 

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py34
+envlist = py26, py27, pypy, py33, py34, py35
 [testenv]
 deps=responses 
      unittest2


### PR DESCRIPTION
Python 3.2 was released on February 20th, 2011 and now it's not supported by requests library https://pypi.python.org/pypi/requests#downloads